### PR TITLE
chore: migrate Renovate preset to recommended

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "prConcurrentLimit": 5,
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
## Summary
- migrate Renovate from `config:base` to `config:recommended`
- preserve the existing `prConcurrentLimit` setting

## Verification
- `python3 -m json.tool .github/renovate.json`
- `git diff --check`

Skipped `atmos test run` because `AGENTS.md` says the Terratest suite deploys/destroys real AWS resources and may incur costs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration settings.

---

**Note:** This release contains only internal configuration updates with no direct impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->